### PR TITLE
Change some type hints to use List instead of list

### DIFF
--- a/boa/plotting.py
+++ b/boa/plotting.py
@@ -9,7 +9,7 @@ from __future__ import annotations
 
 import os
 from itertools import combinations
-from typing import Union
+from typing import List, Union
 
 import numpy as np
 import pandas as pd
@@ -28,7 +28,7 @@ from boa.scheduler import Scheduler
 from boa.storage import scheduler_from_json_file
 
 SchedulerOrPath = Union[Scheduler, os.PathLike, str]
-SchedulersOrPathList = Union[list[Scheduler], list[os.PathLike, str], Scheduler, os.PathLike, str]
+SchedulersOrPathList = Union[List[Scheduler], List[Union[os.PathLike, str]], Scheduler, os.PathLike, str]
 
 
 DEFAULT_CI_LEVEL: float = 0.9

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -96,7 +96,8 @@ autodoc_member_order = "bysource"
 autodoc_typehints = "both"
 
 # autodoc_type_aliases = {
-#     "PathLike": "boa.definitions.PathLike"
+#     "PathLike": "boa.definitions.PathLike",
+#     "SchedulersOrPathList": "boa.plotting.SchedulersOrPathList",
 # }
 # -- Options for HTML output -------------------------------------------------
 
@@ -127,7 +128,6 @@ html_theme_options = {
 
 # For to-do extension
 todo_include_todos = True
-
 
 # external project mapping for intersphinx
 intersphinx_mapping = {


### PR DESCRIPTION
if using `from __future__ import annotations` you can use list directly, but not if it has a custom class as the subscript. SO you can't do `list[MyClass]`, but you can do `list[str]` So changed an instance of list[Scheduler] to List[Scheduler]